### PR TITLE
docs: add session documentation guideline

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -37,3 +37,4 @@ Guidelines:
 - TailwindCSS is used for styling.
 - ESLint is configured for code quality.
 - When running `pnpm dev`, use the specified port from the runtime information.
+- Before creating a pull request, document session changes in docs/sessions/ following the format in docs/instruction.md.

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -37,4 +37,4 @@ Guidelines:
 - TailwindCSS is used for styling.
 - ESLint is configured for code quality.
 - When running `pnpm dev`, use the specified port from the runtime information.
-- Before creating a pull request, document session changes in docs/sessions/ following the format in docs/instruction.md.
+- Before creating a pull request, document session changes in `docs/sessions/` following the format in `docs/instruction.md`.


### PR DESCRIPTION
Added a new guideline to repo.md that requires documenting session changes in docs/sessions/ following the format in docs/instruction.md before creating pull requests.

This helps maintain consistent documentation and makes it easier to track project changes.