### PR TITLE
docs: add session documentation guidelines

### DIFF
--- a/docs/sessions/2025-03-08-15-45-00.md
+++ b/docs/sessions/2025-03-08-15-45-00.md
@@ -1,0 +1,56 @@
+---
+title: Documentation Guidelines Update
+description: Added session documentation requirements to repo.md and established documentation standards for pull requests
+pubDate: 2025-03-08T15:45:00.000Z
+---
+
+# Session Overview
+
+This session focused on improving the project's documentation standards by updating the repository's guidelines to include session documentation requirements. The main goal was to ensure consistent documentation of changes and activities across all pull requests.
+
+# Key Activities
+
+- Reviewed existing repo.md content
+- Added new guideline requiring session documentation before creating pull requests
+- Created and updated pull request with changes
+- Handled merge conflicts and rebased with main branch
+- Prepared session documentation following established format
+
+# Technical Learnings
+
+- Git workflow for handling merge conflicts:
+  - Using `git rebase --abort` when conflicts arise
+  - Resetting branch to main and reapplying changes
+  - Force pushing updates to feature branch
+- Documentation structure:
+  - Understanding the relationship between repo.md and session documentation
+  - Following standardized markdown formatting
+
+# Challenges and Solutions
+
+- Merge Conflict Resolution:
+  - Challenge: Encountered merge conflicts during rebase with main branch
+  - Solution: Adopted a clean-slate approach by resetting to main and reapplying changes
+  - Result: Successfully updated PR with clean git history
+
+# Observations and Patterns
+
+- Documentation Standards:
+  - Clear documentation structure improves project maintainability
+  - Standardized formats help in tracking changes and decisions
+  - Session documentation provides valuable context for code changes
+
+# Future Considerations
+
+- Consider automating parts of the session documentation process
+- May need to establish guidelines for handling concurrent sessions
+- Could benefit from templates or tools to streamline documentation creation
+
+# Final Thoughts
+
+The session successfully established a new documentation requirement that will help maintain better project history and context. The process of handling merge conflicts highlighted the importance of clean git history and proper rebasing techniques. The standardized documentation format will make it easier for team members to understand and track changes across the project's lifecycle.
+
+Key takeaways:
+- Documentation standards are crucial for project maintainability
+- Clean git history helps in managing long-running feature branches
+- Structured session documentation provides valuable context for future reference


### PR DESCRIPTION
This PR adds documentation guidelines and session tracking:

- Added requirement to document session changes in docs/sessions/
- Created first session documentation for this change
- Updated repo.md with new guidelines

All changes follow the format specified in docs/instruction.md.